### PR TITLE
Added nodeSelectors for allocating GPU nodePools in the cloud and configured volumes for WebUI

### DIFF
--- a/kubernetes/helm/templates/ollama-service.yaml
+++ b/kubernetes/helm/templates/ollama-service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: ollama-service
   namespace: {{ .Values.namespace }}
 spec:
+  type: {{ .Values.ollama.service.type }}
   selector:
     app: ollama
   ports:

--- a/kubernetes/helm/templates/ollama-statefulset.yaml
+++ b/kubernetes/helm/templates/ollama-statefulset.yaml
@@ -19,15 +19,32 @@ spec:
         image: {{ .Values.ollama.image }}
         ports:
         - containerPort: {{ .Values.ollama.servicePort }}
-        resources:
-          limits:
-            cpu: {{ .Values.ollama.resources.limits.cpu }}
-            memory: {{ .Values.ollama.resources.limits.memory }}
-            nvidia.com/gpu: {{ .Values.ollama.resources.limits.gpu }}
+        env:
+        {{- if .Values.ollama.gpu.enabled }}
+          - name: PATH
+            value: /usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+          - name: LD_LIBRARY_PATH
+            value: /usr/local/nvidia/lib:/usr/local/nvidia/lib64
+          - name: NVIDIA_DRIVER_CAPABILITIES
+            value: compute,utility
+        {{- end}}
+        {{- if .Values.ollama.resources }}
+        resources: {{- toYaml .Values.ollama.resources | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - name: ollama-volume
           mountPath: /root/.ollama
         tty: true
+      {{- with .Values.ollama.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      tolerations:
+        {{- if .Values.ollama.gpu.enabled }}
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+        {{- end }}
   volumeClaimTemplates:
   - metadata:
       name: ollama-volume
@@ -35,4 +52,4 @@ spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:
-          storage: 1Gi
+          storage: {{ .Values.ollama.volumeSize }}

--- a/kubernetes/helm/templates/webui-deployment.yaml
+++ b/kubernetes/helm/templates/webui-deployment.yaml
@@ -15,14 +15,24 @@ spec:
     spec:
       containers:
       - name: ollama-webui
-        image: ghcr.io/ollama-webui/ollama-webui:main
+        image: {{ .Values.webui.image }}
         ports:
         - containerPort: 8080
-        resources:
-          limits:
-            cpu: "500m"
-            memory: "500Mi"
+        {{- if .Values.webui.resources }}
+        resources: {{- toYaml .Values.webui.resources | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        - name: webui-volume
+          mountPath: /app/backend/data
         env:
         - name: OLLAMA_API_BASE_URL
           value: "http://ollama-service.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.ollama.servicePort }}/api"
         tty: true
+      {{- with .Values.webui.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: webui-volume
+        persistentVolumeClaim:
+          claimName: ollama-webui-pvc

--- a/kubernetes/helm/templates/webui-pvc.yaml
+++ b/kubernetes/helm/templates/webui-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: ollama-webui
+  name: ollama-webui-pvc
+  namespace: {{ .Values.namespace }}  
+spec:
+  accessModes: [ "ReadWriteOnce" ]
+  resources:
+    requests:
+      storage: {{ .Values.webui.volumeSize }}

--- a/kubernetes/helm/templates/webui-service.yaml
+++ b/kubernetes/helm/templates/webui-service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ollama-webui-service
   namespace: {{ .Values.namespace }}
 spec:
-  type: NodePort  # Use LoadBalancer if you're on a cloud that supports it
+  type: {{ .Values.webui.service.type }} # Default: NodePort  # Use LoadBalancer if you're on a cloud that supports it
   selector:
     app: ollama-webui
   ports:

--- a/kubernetes/helm/values.yaml
+++ b/kubernetes/helm/values.yaml
@@ -10,6 +10,12 @@ ollama:
       memory: "2Gi"
       nvidia.com/gpu: "0"
   volumeSize: 1Gi
+  nodeSelector: {}
+  tolerations: []
+  service:
+    type: ClusterIP
+  gpu:
+    enabled: false
 
 webui:
   replicaCount: 1
@@ -25,3 +31,8 @@ webui:
     # Use appropriate annotations for your Ingress controller, e.g., for NGINX:
       # nginx.ingress.kubernetes.io/rewrite-target: /
     host: ollama.minikube.local
+  volumeSize: 1Gi
+  nodeSelector: {}
+  tolerations: []
+  service:
+    type: NodePort


### PR DESCRIPTION
## Summary

Added GPU support (selectors) for Cloud environments and added persistent storage for WebUI.

1. **WebUI Service Type Customisation**: The service type for WebUI is now configurable, with NodePool as the default setting. This change provides more flexibility as it was previously hardcoded to NodePool.

2. **NodeSelector Configurations**: Added configurations for nodeSelector. This feature is essential for selecting GPU-backed node pools in the cloud.

3. **Dynamic Resource Specification**: The `resources` specification has been revised to be more dynamic, allowing for greater adaptability.

4. **NVIDIA GPU Drivers for Ollama-statefulset**: Introduced environment variables to enable NVIDIA GPU drivers for the `ollama-statefulset`.

5. **VolumeSize Parameter Fix for Ollama-statefulset**: Corrected the `volumeSize` parameter for `ollama-statefulset`, which was previously hardcoded (most likely a typo).

6. **Image Parameter Fix for WebUI-Deployment**: Corrected the `image` parameter for `webui-deployment` which was previously hardcoded (most likely a typo).

7. **PersistentVolume/PersistentVolume Claim for WebUI**: Added a `persistentVolume`/`persistentVolumeClaim` to WebUI to support the new authentication model.

## Testing

The above changes have been tested on GKE (with NVIDIA GPU's) using the `values.yaml` provided below.

1. **Persistence of Chat and User History**: The chat and user history in WebUI persisted even after killing/restarting the pod and starting a new session in a different browser.

2. **GPU Generation**: The GPU generation worked as expected. The results were much quicker when tested with `llava` and `codellama`.

3. **Custom ModelFiles**: Custom `ModelFiles` were not tested (sorry I'm not familiar with model files).

Here is the `values.yaml` configuration used for testing:

```yaml
namespace: ollama

ollama:
  gpu:
    enabled: "true"
  nodeSelector:
    cloud.google.com/gke-spot: "true"
    cloud.google.com/gke-accelerator: "nvidia-tesla-t4"
  resources:
    requests:
      memory: 8192Mi
      cpu: 4000m
    limits:
      memory: 8192Mi
      cpu: 4000m
      nvidia.com/gpu: "2"
  volumeSize: 40Gi

webui:
  service:
    type: ClusterIP #LoadBalancer
  nodeSelector:
    cloud.google.com/gke-spot: "true"
  ingress:
    enabled: true
    host: ollama.braveokafor.com
    annotations:
      kubernetes.io/ingress.global-static-ip-name: ollama
      kubernetes.io/ingress.class: gce
  volumeSize: 2Gi
```